### PR TITLE
fix gitops rbac

### DIFF
--- a/instance/base/clusterrole.yaml
+++ b/instance/base/clusterrole.yaml
@@ -1,0 +1,13 @@
+---
+# oc create clusterrole nmstate-mgr --verb='*' --resource NMstate --dry-run=client -o yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nmstate-mgr
+rules:
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nmstates
+  verbs:
+  - '*'

--- a/instance/base/clusterrolebinding.yaml
+++ b/instance/base/clusterrolebinding.yaml
@@ -1,13 +1,13 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: openshift-gitops-argocd-server-nmstate
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: nmstate-mgr
 subjects:
   - kind: ServiceAccount

--- a/instance/base/kustomization.yaml
+++ b/instance/base/kustomization.yaml
@@ -6,3 +6,5 @@ namespace: openshift-nmstate
 
 resources:
   - nmstate.yaml
+  - role.yaml
+  - rolebinding.yaml

--- a/instance/base/kustomization.yaml
+++ b/instance/base/kustomization.yaml
@@ -7,4 +7,6 @@ namespace: openshift-nmstate
 resources:
   - nmstate.yaml
   - role.yaml
+  - clusterrole.yaml
   - rolebinding.yaml
+  - clusterrolebinding.yaml

--- a/instance/base/nmstate.yaml
+++ b/instance/base/nmstate.yaml
@@ -3,6 +3,4 @@ apiVersion: nmstate.io/v1
 kind: NMState
 metadata:
   name: nmstate
-  labels:
-    app.kubernetes.io/instance: nmstate-config
 spec: {}

--- a/instance/base/role.yaml
+++ b/instance/base/role.yaml
@@ -1,0 +1,18 @@
+# oc create role metallb-mgr --verb='*' --resource=MetalLB -n metallb-system --dry-run=client -o yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: nmstate-mgr
+  namespace: openshift-nmstate
+rules:
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nmstates
+  - nmstateconfigs
+  - nodenetworkconfigurationpolicies
+  verbs:
+  - '*'

--- a/instance/base/role.yaml
+++ b/instance/base/role.yaml
@@ -1,7 +1,7 @@
 # oc create role metallb-mgr --verb='*' --resource=MetalLB -n metallb-system --dry-run=client -o yaml
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"

--- a/instance/base/role.yaml
+++ b/instance/base/role.yaml
@@ -1,18 +1,19 @@
-# oc create role metallb-mgr --verb='*' --resource=MetalLB -n metallb-system --dry-run=client -o yaml
 ---
+#oc create role nmstate-mgr --verb='*' --resource nncp,nmstateconfig --dry-run=client -o yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
   name: nmstate-mgr
-  namespace: openshift-nmstate
 rules:
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - nmstateconfigs
+  verbs:
+  - '*'
 - apiGroups:
   - nmstate.io
   resources:
-  - nmstates
-  - nmstateconfigs
   - nodenetworkconfigurationpolicies
   verbs:
   - '*'

--- a/instance/base/rolebinding.yaml
+++ b/instance/base/rolebinding.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: openshift-gitops-argocd-server-nmstate
   annotations:
@@ -10,9 +10,12 @@ roleRef:
   kind: Role
   name: nmstate-mgr
 subjects:
-- kind: ServiceAccount
-  name: openshift-gitops-argocd-server
-  namespace: openshift-gitops
+  #- kind: ServiceAccount
+  #name: openshift-gitops-argocd-server
+  #namespace: openshift-gitops
 - kind: ServiceAccount
   name: openshift-gitops-argocd-application-controller
   namespace: openshift-gitops
+
+
+#  Partial sync operation to failed: one or more objects failed to apply, reason: nmstates.nmstate.io is forbidden: User "system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller" cannot create resource "nmstates" in API group "nmstate.io" at the cluster scope

--- a/instance/base/rolebinding.yaml
+++ b/instance/base/rolebinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-gitops-argocd-server-nmstate
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nmstate-mgr
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-server
+  namespace: openshift-gitops

--- a/instance/base/rolebinding.yaml
+++ b/instance/base/rolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: nmstate-mgr
 subjects:
   #- kind: ServiceAccount

--- a/instance/base/rolebinding.yaml
+++ b/instance/base/rolebinding.yaml
@@ -13,3 +13,6 @@ subjects:
 - kind: ServiceAccount
   name: openshift-gitops-argocd-server
   namespace: openshift-gitops
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops


### PR DESCRIPTION
enable argocd mgmt of nmstates, nncps - remember nmstate is not namespaced
enable argocd mgmt of nmstateconfigs even though that is a different API (bad idea probably)